### PR TITLE
修复在UWP平台编译错误，std::codecvt_*等函数被淘汰

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,8 @@ if (MSVC AND USE_STATIC_CRT)
     endforeach()
 endif()
 
+add_definitions(-D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
+
 if(UNIX)
   file(GLOB SRC_FILES ${LIBIPC_PROJECT_DIR}/src/libipc/platform/*_linux.cpp)
 else()


### PR DESCRIPTION
错误如下：
```
     4>D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\libipc/platform/to_tchar.h(44,14): error C4996: 'std::codecvt_utf8_utf16<wchar_t,1114111,(std::codecvt_mode)0>': warning STL4017: std::wbuffer_convert, std::wstring_convert, and the <codecvt> header (containing std::codecvt_mode, std::codecvt_utf8, std::codecvt_utf16, and std::codecvt_utf8_utf16) are deprecated in C++17. (The std::codecvt class template is NOT deprecated.) The C++ Standard doesn't provide equivalent non-deprecated functionality; consider using MultiByteToWideChar() and WideCharToMultiByte() from <Windows.h> instead. You can define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING or _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS to acknowledge that you have received this warning. (compiling source file D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\libipc\platform\shm_win.cpp) [D:\buildtrees\libipc\x64-uwp-dbg\src\ipc.vcxproj]
       C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30037\include\codecvt(428,5): message : see declaration of 'std::codecvt_utf8_utf16' (compiling source file D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\libipc\platform\shm_win.cpp) [D:\buildtrees\libipc\x64-uwp-dbg\src\ipc.vcxproj]
       D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\libipc\platform\shm_win.cpp(35): message : see reference to function template instantiation 'std::basic_string<wchar_t,std::char_traits<wchar_t>,ipc::mem::allocator_wrapper<wchar_t,ipc::mem::async_pool_alloc>> ipc::detail::to_tchar<TCHAR>(ipc::string &&)' being compiled [D:\buildtrees\libipc\x64-uwp-dbg\src\ipc.vcxproj]
     4>D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\libipc/platform/to_tchar.h(43,17): error C4996: 'std::wstring_convert<std::codecvt_utf8_utf16<wchar_t,1114111,(std::codecvt_mode)0>,wchar_t,ipc::mem::allocator_wrapper<wchar_t,ipc::mem::async_pool_alloc>,ipc::mem::allocator_wrapper<char,ipc::mem::async_pool_alloc>>': warning STL4017: std::wbuffer_convert, std::wstring_convert, and the <codecvt> header (containing std::codecvt_mode, std::codecvt_utf8, std::codecvt_utf16, and std::codecvt_utf8_utf16) are deprecated in C++17. (The std::codecvt class template is NOT deprecated.) The C++ Standard doesn't provide equivalent non-deprecated functionality; consider using MultiByteToWideChar() and WideCharToMultiByte() from <Windows.h> instead. You can define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING or _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS to acknowledge that you have received this warning. (compiling source file D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\libipc\platform\shm_win.cpp) [D:\buildtrees\libipc\x64-uwp-dbg\src\ipc.vcxproj]
       C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30037\include\xlocbuf(302,55): message : see declaration of 'std::wstring_convert' (compiling source file D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\libipc\platform\shm_win.cpp) [D:\buildtrees\libipc\x64-uwp-dbg\src\ipc.vcxproj]
     4>D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\libipc/platform/to_tchar.h(48,8): error C4996: 'std::wstring_convert<std::codecvt_utf8_utf16<wchar_t,1114111,(std::codecvt_mode)0>,wchar_t,ipc::mem::allocator_wrapper<wchar_t,ipc::mem::async_pool_alloc>,ipc::mem::allocator_wrapper<char,ipc::mem::async_pool_alloc>>::from_bytes': warning STL4017: std::wbuffer_convert, std::wstring_convert, and the <codecvt> header (containing std::codecvt_mode, std::codecvt_utf8, std::codecvt_utf16, and std::codecvt_utf8_utf16) are deprecated in C++17. (The std::codecvt class template is NOT deprecated.) The C++ Standard doesn't provide equivalent non-deprecated functionality; consider using MultiByteToWideChar() and WideCharToMultiByte() from <Windows.h> instead. You can define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING or _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS to acknowledge that you have received this warning. (compiling source file D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\libipc\platform\shm_win.cpp) [D:\buildtrees\libipc\x64-uwp-dbg\src\ipc.vcxproj]
     4>D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\libipc/platform/to_tchar.h(44,14): error C4996: 'std::codecvt_utf8_utf16<wchar_t,1114111,(std::codecvt_mode)0>': warning STL4017: std::wbuffer_convert, std::wstring_convert, and the <codecvt> header (containing std::codecvt_mode, std::codecvt_utf8, std::codecvt_utf16, and std::codecvt_utf8_utf16) are deprecated in C++17. (The std::codecvt class template is NOT deprecated.) The C++ Standard doesn't provide equivalent non-deprecated functionality; consider using MultiByteToWideChar() and WideCharToMultiByte() from <Windows.h> instead. You can define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING or _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS to acknowledge that you have received this warning. (compiling source file D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\waiter.cpp) [D:\buildtrees\libipc\x64-uwp-dbg\src\ipc.vcxproj]
       C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30037\include\codecvt(428,5): message : see declaration of 'std::codecvt_utf8_utf16' (compiling source file D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\waiter.cpp) [D:\buildtrees\libipc\x64-uwp-dbg\src\ipc.vcxproj]
       D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\libipc/platform/waiter_win.h(31): message : see reference to function template instantiation 'std::basic_string<wchar_t,std::char_traits<wchar_t>,ipc::mem::allocator_wrapper<wchar_t,ipc::mem::async_pool_alloc>> ipc::detail::to_tchar<TCHAR>(ipc::string &&)' being compiled (compiling source file D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\waiter.cpp) [D:\buildtrees\libipc\x64-uwp-dbg\src\ipc.vcxproj]
     4>D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\libipc/platform/to_tchar.h(43,17): error C4996: 'std::wstring_convert<std::codecvt_utf8_utf16<wchar_t,1114111,(std::codecvt_mode)0>,wchar_t,ipc::mem::allocator_wrapper<wchar_t,ipc::mem::async_pool_alloc>,ipc::mem::allocator_wrapper<char,ipc::mem::async_pool_alloc>>': warning STL4017: std::wbuffer_convert, std::wstring_convert, and the <codecvt> header (containing std::codecvt_mode, std::codecvt_utf8, std::codecvt_utf16, and std::codecvt_utf8_utf16) are deprecated in C++17. (The std::codecvt class template is NOT deprecated.) The C++ Standard doesn't provide equivalent non-deprecated functionality; consider using MultiByteToWideChar() and WideCharToMultiByte() from <Windows.h> instead. You can define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING or _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS to acknowledge that you have received this warning. (compiling source file D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\waiter.cpp) [D:\buildtrees\libipc\x64-uwp-dbg\src\ipc.vcxproj]
       C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30037\include\xlocbuf(302,55): message : see declaration of 'std::wstring_convert' (compiling source file D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\waiter.cpp) [D:\buildtrees\libipc\x64-uwp-dbg\src\ipc.vcxproj]
     4>D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\libipc/platform/to_tchar.h(48,8): error C4996: 'std::wstring_convert<std::codecvt_utf8_utf16<wchar_t,1114111,(std::codecvt_mode)0>,wchar_t,ipc::mem::allocator_wrapper<wchar_t,ipc::mem::async_pool_alloc>,ipc::mem::allocator_wrapper<char,ipc::mem::async_pool_alloc>>::from_bytes': warning STL4017: std::wbuffer_convert, std::wstring_convert, and the <codecvt> header (containing std::codecvt_mode, std::codecvt_utf8, std::codecvt_utf16, and std::codecvt_utf8_utf16) are deprecated in C++17. (The std::codecvt class template is NOT deprecated.) The C++ Standard doesn't provide equivalent non-deprecated functionality; consider using MultiByteToWideChar() and WideCharToMultiByte() from <Windows.h> instead. You can define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING or _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS to acknowledge that you have received this warning. (compiling source file D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\waiter.cpp) [D:\buildtrees\libipc\x64-uwp-dbg\src\ipc.vcxproj]
     4>D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\libipc/platform/to_tchar.h(44,14): error C4996: 'std::codecvt_utf8_utf16<wchar_t,1114111,(std::codecvt_mode)0>': warning STL4017: std::wbuffer_convert, std::wstring_convert, and the <codecvt> header (containing std::codecvt_mode, std::codecvt_utf8, std::codecvt_utf16, and std::codecvt_utf8_utf16) are deprecated in C++17. (The std::codecvt class template is NOT deprecated.) The C++ Standard doesn't provide equivalent non-deprecated functionality; consider using MultiByteToWideChar() and WideCharToMultiByte() from <Windows.h> instead. You can define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING or _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS to acknowledge that you have received this warning. (compiling source file D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\ipc.cpp) [D:\buildtrees\libipc\x64-uwp-dbg\src\ipc.vcxproj]
       C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30037\include\codecvt(428,5): message : see declaration of 'std::codecvt_utf8_utf16' (compiling source file D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\ipc.cpp) [D:\buildtrees\libipc\x64-uwp-dbg\src\ipc.vcxproj]
       D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\libipc/platform/waiter_win.h(31): message : see reference to function template instantiation 'std::basic_string<wchar_t,std::char_traits<wchar_t>,ipc::mem::allocator_wrapper<wchar_t,ipc::mem::async_pool_alloc>> ipc::detail::to_tchar<TCHAR>(ipc::string &&)' being compiled (compiling source file D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\ipc.cpp) [D:\buildtrees\libipc\x64-uwp-dbg\src\ipc.vcxproj]
     4>D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\libipc/platform/to_tchar.h(43,17): error C4996: 'std::wstring_convert<std::codecvt_utf8_utf16<wchar_t,1114111,(std::codecvt_mode)0>,wchar_t,ipc::mem::allocator_wrapper<wchar_t,ipc::mem::async_pool_alloc>,ipc::mem::allocator_wrapper<char,ipc::mem::async_pool_alloc>>': warning STL4017: std::wbuffer_convert, std::wstring_convert, and the <codecvt> header (containing std::codecvt_mode, std::codecvt_utf8, std::codecvt_utf16, and std::codecvt_utf8_utf16) are deprecated in C++17. (The std::codecvt class template is NOT deprecated.) The C++ Standard doesn't provide equivalent non-deprecated functionality; consider using MultiByteToWideChar() and WideCharToMultiByte() from <Windows.h> instead. You can define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING or _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS to acknowledge that you have received this warning. (compiling source file D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\ipc.cpp) [D:\buildtrees\libipc\x64-uwp-dbg\src\ipc.vcxproj]
       C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30037\include\xlocbuf(302,55): message : see declaration of 'std::wstring_convert' (compiling source file D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\ipc.cpp) [D:\buildtrees\libipc\x64-uwp-dbg\src\ipc.vcxproj]
     4>D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\libipc/platform/to_tchar.h(48,8): error C4996: 'std::wstring_convert<std::codecvt_utf8_utf16<wchar_t,1114111,(std::codecvt_mode)0>,wchar_t,ipc::mem::allocator_wrapper<wchar_t,ipc::mem::async_pool_alloc>,ipc::mem::allocator_wrapper<char,ipc::mem::async_pool_alloc>>::from_bytes': warning STL4017: std::wbuffer_convert, std::wstring_convert, and the <codecvt> header (containing std::codecvt_mode, std::codecvt_utf8, std::codecvt_utf16, and std::codecvt_utf8_utf16) are deprecated in C++17. (The std::codecvt class template is NOT deprecated.) The C++ Standard doesn't provide equivalent non-deprecated functionality; consider using MultiByteToWideChar() and WideCharToMultiByte() from <Windows.h> instead. You can define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING or _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS to acknowledge that you have received this warning. (compiling source file D:\buildtrees\libipc\src\69ef53e097-7f6cebad2c.clean\src\ipc.cpp) [D:\buildtrees\libipc\x64-uwp-dbg\src\ipc.vcxproj]
     4>C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\XamlCompiler\Microsoft.Windows.UI.Xaml.Common.targets(486,5): error MSB4181: The "CompileXaml" task returned false but did not log an error. [D:\buildtrees\libipc\x64-uwp-dbg\src\ipc.vcxproj]
     4>Done Building Project "D:\buildtrees\libipc\x64-uwp-dbg\src\ipc.vcxproj" (default targets) -- FAILED.
     3>Done Building Project "D:\buildtrees\libipc\x64-uwp-dbg\ALL_BUILD.vcxproj" (default targets) -- FAILED.
     1>Done Building Project "D:\buildtrees\libipc\x64-uwp-dbg\install.vcxproj" (default targets) -- FAILED.
```