### PR TITLE
Add cpp-ipc-targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,7 +40,9 @@ set_target_properties(${PROJECT_NAME}
     SOVERSION 3)
 
 target_include_directories(${PROJECT_NAME}
-  PUBLIC  ${LIBIPC_PROJECT_DIR}/include
+  PUBLIC  
+    "$<BUILD_INTERFACE:${LIBIPC_PROJECT_DIR}/include>"
+    "$<INSTALL_INTERFACE:include>"
   PRIVATE ${LIBIPC_PROJECT_DIR}/src
           $<$<BOOL:UNIX>:${LIBIPC_PROJECT_DIR}/src/libipc/platform/linux>)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(ipc)
 
+set (PACKAGE_VERSION 1.3.0)
+
 aux_source_directory(${LIBIPC_PROJECT_DIR}/src/libipc SRC_FILES)
 aux_source_directory(${LIBIPC_PROJECT_DIR}/src/libipc/sync SRC_FILES)
 aux_source_directory(${LIBIPC_PROJECT_DIR}/src/libipc/platform SRC_FILES)
@@ -34,7 +36,7 @@ set_target_properties(${PROJECT_NAME}
 # set version
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
-    VERSION 1.2.0
+    VERSION ${PACKAGE_VERSION}
     SOVERSION 3)
 
 target_include_directories(${PROJECT_NAME}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,28 @@ endif()
 
 install(
   TARGETS ${PROJECT_NAME}
+  EXPORT cpp-ipc-targets
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)
+
+install(EXPORT cpp-ipc-targets
+	FILE cpp-ipc-targets.cmake
+	NAMESPACE cpp-ipc::
+	DESTINATION share/cpp-ipc
+)
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/cpp-ipc-config.cmake.in"
+[[include(CMakeFindDependencyMacro)
+include("${CMAKE_CURRENT_LIST_DIR}/cpp-ipc-targets.cmake")
+]])
+configure_file("${CMAKE_CURRENT_BINARY_DIR}/cpp-ipc-config.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/cpp-ipc-config.cmake" @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cpp-ipc-config.cmake DESTINATION share/cpp-ipc)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+	cppIpcConfigVersion.cmake
+	VERSION ${PACKAGE_VERSION}
+	COMPATIBILITY AnyNewerVersion
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cppIpcConfigVersion.cmake DESTINATION share/cpp-ipc)


### PR DESCRIPTION
主要用于修复bug #110 

待合并这个PR后，我再提交最新代码到vcpkg。

添加`cpp-ipc-targets`后，支持使用find_package查找安装的包。以echo程序为例，将echo移动到项目外后，CMake修改为如下即可：
```
cmake_minimum_required(VERSION 3.26)
project(chat)

file(GLOB SRC_FILES ./*.cpp)
file(GLOB HEAD_FILES ./*.h)

add_executable(${PROJECT_NAME} ${SRC_FILES} ${HEAD_FILES})

find_package(cpp-ipc CONFIG REQUIRED)
target_link_libraries(chat PRIVATE cpp-ipc::ipc)
```

---

 **添加了`PACKAGE_VERSION`选项，如有Release新版本，请更新该变量。**