### PR TITLE
fix emplace construction for shm_data. Previous required copy constru…

### DIFF
--- a/src/libipc/platform/linux/mutex.h
+++ b/src/libipc/platform/linux/mutex.h
@@ -125,8 +125,11 @@ class mutex {
         IPC_UNUSED_ std::lock_guard<std::mutex> guard {info.lock};
         auto it = info.mutex_handles.find(name);
         if (it == info.mutex_handles.end()) {
-            it = info.mutex_handles.emplace(name, 
-                  curr_prog::shm_data::init{name}).first;
+            it = info.mutex_handles
+                   .emplace(
+                       std::piecewise_construct, std::forward_as_tuple(name),
+                       std::forward_as_tuple(curr_prog::shm_data::init{name}))
+                   .first;
         }
         mutex_ = &it->second.mtx;
         ref_   = &it->second.ref;

--- a/src/libipc/platform/posix/mutex.h
+++ b/src/libipc/platform/posix/mutex.h
@@ -55,8 +55,12 @@ class mutex {
         IPC_UNUSED_ std::lock_guard<std::mutex> guard {info.lock};
         auto it = info.mutex_handles.find(name);
         if (it == info.mutex_handles.end()) {
-            it = info.mutex_handles.emplace(name, 
-                  curr_prog::shm_data::init{name, sizeof(pthread_mutex_t)}).first;
+          it = info.mutex_handles
+                   .emplace(std::piecewise_construct,
+                            std::forward_as_tuple(name),
+                            std::forward_as_tuple(curr_prog::shm_data::init{
+                                name, sizeof(pthread_mutex_t)}))
+                   .first;
         }
         shm_ = &it->second.shm;
         ref_ = &it->second.ref;


### PR DESCRIPTION
Current implementation may not compile due to shm_data being non-copyable.

The only proper std::pair constructor is number 9 https://en.cppreference.com/w/cpp/utility/pair/pair 