### PR TITLE
Fixed issues #107 and #123,  receiver check connection and when pop msg fail…

### DIFF
--- a/src/libipc/ipc.cpp
+++ b/src/libipc/ipc.cpp
@@ -627,7 +627,10 @@ static ipc::buff_t recv(ipc::handle_t h, std::uint64_t tm) {
     for (;;) {
         // pop a new message
         typename queue_t::value_t msg {};
-        if (!wait_for(inf->rd_waiter_, [que, &msg] {
+        if (!wait_for(inf->rd_waiter_, [que, &msg, &h] {
+                if (!que->connected(que->elems())) {
+                    reconnect(&h, true);
+                }
                 return !que->pop(msg);
             }, tm)) {
             // pop failed, just return.

--- a/src/libipc/queue.h
+++ b/src/libipc/queue.h
@@ -67,6 +67,11 @@ public:
         return connected_ != 0;
     }
 
+    template <typename Elems>
+    bool connected(Elems* elems) noexcept {
+        return connected_ & elems->connections();
+    }
+
     circ::cc_t connected_id() const noexcept {
         return connected_;
     }
@@ -77,16 +82,16 @@ public:
      -> std::tuple<bool, bool, decltype(std::declval<Elems>().cursor())> {
         if (elems == nullptr) return {};
         // if it's already connected, just return
-        if (connected()) return {connected(), false, 0};
+        if (connected(elems)) return {connected(elems), false, 0};
         connected_ = elems->connect_receiver();
-        return {connected(), true, elems->cursor()};
+        return {connected(elems), true, elems->cursor()};
     }
 
     template <typename Elems>
     bool disconnect(Elems* elems) noexcept {
         if (elems == nullptr) return false;
         // if it's already disconnected, just return false
-        if (!connected()) return false;
+        if (!connected(elems)) return false;
         elems->disconnect_receiver(std::exchange(connected_, 0));
         return true;
     }


### PR DESCRIPTION
Fixed issues #107 and #123. The receiver now checks the connection status when popping a message fails, and calls the reconnect function if the connection check indicates that the connection is down. The root cause of the receiver's failure to pop a message is that the sender process invokes force_push() when it fails to push data into the circular queue. The force_push() function then identifies which receiver has not read the data and disconnects it. Typically, the receiver process hasn't read the data because it is either blocked (e.g., paused at a breakpoint) or stuck (when the system CPU load is high). Consequently, the receiver process has no way of knowing whether the connection was disconnected and will either wait on ::SignalObjectAndWait (when there is only one receiver in the connection) or endlessly retry popping the message.

Therefore, the solution involves making the receiver aware of disconnections so it can take action to recover, such as calling the reconnect() function. To achieve this, I have optimized the connect function and added reconnection logic in the recv() function. This approach has proven effective.