### PR TITLE
mingw: use lower case windows.h

### DIFF
--- a/demo/win_service/client/main.cpp
+++ b/demo/win_service/client/main.cpp
@@ -1,6 +1,10 @@
 /// \brief To create a basic Windows command line program.
 
+#if defined(__MINGW32__)
+#include <windows.h>
+#else
 #include <Windows.h>
+#endif
 #include <tchar.h>
 #include <stdio.h>
 

--- a/demo/win_service/service/main.cpp
+++ b/demo/win_service/service/main.cpp
@@ -1,7 +1,11 @@
 /// \brief To create a basic Windows Service in C++.
 /// \see https://www.codeproject.com/Articles/499465/Simple-Windows-Service-in-Cplusplus
 
+#if defined(__MINGW32__)
+#include <windows.h>
+#else
 #include <Windows.h>
+#endif
 #include <tchar.h>
 #include <string>
 

--- a/src/libipc/platform/win/condition.h
+++ b/src/libipc/platform/win/condition.h
@@ -4,7 +4,11 @@
 #include <string>
 #include <mutex>
 
+#if defined(__MINGW32__)
+#include <windows.h>
+#else
 #include <Windows.h>
+#endif
 
 #include "libipc/utility/log.h"
 #include "libipc/utility/scope_guard.h"

--- a/src/libipc/platform/win/mutex.h
+++ b/src/libipc/platform/win/mutex.h
@@ -3,7 +3,11 @@
 #include <cstdint>
 #include <system_error>
 
+#if defined(__MINGW32__)
+#include <windows.h>
+#else
 #include <Windows.h>
+#endif
 
 #include "libipc/utility/log.h"
 

--- a/src/libipc/platform/win/semaphore.h
+++ b/src/libipc/platform/win/semaphore.h
@@ -2,7 +2,11 @@
 
 #include <cstdint>
 
+#if defined(__MINGW32__)
+#include <windows.h>
+#else
 #include <Windows.h>
+#endif
 
 #include "libipc/utility/log.h"
 

--- a/src/libipc/platform/win/shm_win.cpp
+++ b/src/libipc/platform/win/shm_win.cpp
@@ -1,5 +1,9 @@
 
+#if defined(__MINGW32__)
+#include <windows.h>
+#else
 #include <Windows.h>
+#endif
 
 #include <string>
 #include <utility>

--- a/src/libipc/platform/win/to_tchar.h
+++ b/src/libipc/platform/win/to_tchar.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#if defined(__MINGW32__)
+#include <windows.h>
+#else
 #include <Windows.h>
+#endif
 
 #include <type_traits>
 #include <string>

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -37,7 +37,11 @@ TEST(PThread, Robust) {
     pthread_mutex_destroy(&mutex);
 }
 #elif defined(IPC_OS_WINDOWS_)
+#if defined(__MINGW32__)
+#include <windows.h>
+#else
 #include <Windows.h>
+#endif
 #include <tchar.h>
 
 TEST(PThread, Robust) {


### PR DESCRIPTION
When compiling on linux, windows.h is lower case, without this patch the build fails.

Alternative is just to make it lower case anyway, as this will work on 99% of users as NTFS is generally used case insensitive by most.

Let me know and I can adjust if necessary