### PR TITLE
Add FreeBSD platform support (fixes #156)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/github/mutouyun/cpp-ipc?branch=master&svg=true)](https://ci.appveyor.com/project/mutouyun/cpp-ipc)
 [![Vcpkg package](https://img.shields.io/badge/Vcpkg-package-blueviolet)](https://github.com/microsoft/vcpkg/tree/master/ports/cpp-ipc)
 
-## A high-performance inter-process communication library using shared memory on Linux/Windows.
+## A high-performance inter-process communication library using shared memory on Linux/Windows/FreeBSD.
 
  * Compilers with C++17 support are recommended (msvc-2017/gcc-7/clang-4)
  * No other dependencies except STL.
@@ -44,7 +44,7 @@ Performance data: [performance.xlsx](performance.xlsx)
 ------
 
 
-## 使用共享内存的跨平台（Linux/Windows，x86/x64/ARM）高性能IPC通讯库
+## 使用共享内存的跨平台（Linux/Windows/FreeBSD，x86/x64/ARM）高性能IPC通讯库
 
  * 推荐支持C++17的编译器（msvc-2017/gcc-7/clang-4）
  * 除STL外，无其他依赖

--- a/src/libipc/platform/detail.h
+++ b/src/libipc/platform/detail.h
@@ -9,6 +9,8 @@
 #   define IPC_OS_WINDOWS_
 #elif defined(__linux__) || defined(__linux)
 #   define IPC_OS_LINUX_
+#elif defined(__FreeBSD__)
+#   define IPC_OS_FREEBSD_
 #elif defined(__QNX__)
 #   define IPC_OS_QNX_
 #elif defined(__APPLE__)

--- a/src/libipc/platform/platform.c
+++ b/src/libipc/platform/platform.c
@@ -7,7 +7,7 @@
 #include "libipc/platform/linux/a0/strconv.c"
 #include "libipc/platform/linux/a0/tid.c"
 #include "libipc/platform/linux/a0/time.c"
-#elif defined(IPC_OS_QNX_)
+#elif defined(IPC_OS_QNX_) || defined(IPC_OS_FREEBSD_)
 #else/*IPC_OS*/
 #   error "Unsupported platform."
 #endif

--- a/src/libipc/platform/platform.cpp
+++ b/src/libipc/platform/platform.cpp
@@ -2,7 +2,7 @@
 #include "libipc/platform/detail.h"
 #if defined(IPC_OS_WINDOWS_)
 #include "libipc/platform/win/shm_win.cpp"
-#elif defined(IPC_OS_LINUX_) || defined(IPC_OS_QNX_)
+#elif defined(IPC_OS_LINUX_) || defined(IPC_OS_QNX_) || defined(IPC_OS_FREEBSD_)
 #include "libipc/platform/posix/shm_posix.cpp"
 #else/*IPC_OS*/
 #   error "Unsupported platform."

--- a/src/libipc/sync/condition.cpp
+++ b/src/libipc/sync/condition.cpp
@@ -9,7 +9,7 @@
 #include "libipc/platform/win/condition.h"
 #elif defined(IPC_OS_LINUX_)
 #include "libipc/platform/linux/condition.h"
-#elif defined(IPC_OS_QNX_)
+#elif defined(IPC_OS_QNX_) || defined(IPC_OS_FREEBSD_)
 #include "libipc/platform/posix/condition.h"
 #else/*IPC_OS*/
 #   error "Unsupported platform."

--- a/src/libipc/sync/mutex.cpp
+++ b/src/libipc/sync/mutex.cpp
@@ -9,7 +9,7 @@
 #include "libipc/platform/win/mutex.h"
 #elif defined(IPC_OS_LINUX_)
 #include "libipc/platform/linux/mutex.h"
-#elif defined(IPC_OS_QNX_)
+#elif defined(IPC_OS_QNX_) || defined(IPC_OS_FREEBSD_)
 #include "libipc/platform/posix/mutex.h"
 #else/*IPC_OS*/
 #   error "Unsupported platform."

--- a/src/libipc/sync/semaphore.cpp
+++ b/src/libipc/sync/semaphore.cpp
@@ -7,7 +7,7 @@
 #include "libipc/platform/detail.h"
 #if defined(IPC_OS_WINDOWS_)
 #include "libipc/platform/win/semaphore.h"
-#elif defined(IPC_OS_LINUX_) || defined(IPC_OS_QNX_)
+#elif defined(IPC_OS_LINUX_) || defined(IPC_OS_QNX_) || defined(IPC_OS_FREEBSD_)
 #include "libipc/platform/posix/semaphore_impl.h"
 #else/*IPC_OS*/
 #   error "Unsupported platform."

--- a/src/libipc/sync/waiter.cpp
+++ b/src/libipc/sync/waiter.cpp
@@ -5,7 +5,7 @@
 #include "libipc/platform/win/mutex.h"
 #elif defined(IPC_OS_LINUX_)
 #include "libipc/platform/linux/mutex.h"
-#elif defined(IPC_OS_QNX_)
+#elif defined(IPC_OS_QNX_) || defined(IPC_OS_FREEBSD_)
 #include "libipc/platform/posix/mutex.h"
 #else/*IPC_OS*/
 #   error "Unsupported platform."


### PR DESCRIPTION
## Summary

This PR adds FreeBSD platform support to cpp-ipc by reusing the existing POSIX pthread implementation.

## Changes

- **Platform Detection**: Added `IPC_OS_FREEBSD_` macro to `src/libipc/platform/detail.h`
- **Conditional Compilation**: Updated all sync modules to include FreeBSD alongside QNX for POSIX implementation
- **Documentation**: Updated README.md to reflect FreeBSD platform support

## Technical Details

FreeBSD uses the existing POSIX implementation (`src/libipc/platform/posix/`) which provides:
- Process-shared mutexes (`PTHREAD_PROCESS_SHARED`)
- Robust mutexes (`PTHREAD_MUTEX_ROBUST`)
- Timed lock operations (`pthread_mutex_timedlock`, `pthread_cond_timedwait`)
- POSIX shared memory (`shm_open`, `shm_unlink`)

## Why This Approach?

1. **Minimal Changes**: Only 8 files modified, 10 lines of code changed
2. **Low Risk**: Reuses mature POSIX implementation already proven by QNX platform
3. **Complete Functionality**: FreeBSD's POSIX implementation fully supports all required features
4. **Easy Maintenance**: FreeBSD and QNX share the same implementation

## Testing

The changes are minimal and non-invasive:
- No changes to existing platform implementations (Linux, Windows, QNX)
- No API changes
- FreeBSD will use the same POSIX code path as QNX

Ideally, this should be tested on a FreeBSD system to verify:
- Compilation succeeds
- Unit tests pass
- Demo programs work correctly

## Files Modified

- `README.md` - Added FreeBSD to platform list
- `src/libipc/platform/detail.h` - Added FreeBSD platform detection
- `src/libipc/platform/platform.c` - Updated conditional compilation
- `src/libipc/platform/platform.cpp` - Updated conditional compilation
- `src/libipc/sync/condition.cpp` - Updated conditional compilation
- `src/libipc/sync/mutex.cpp` - Updated conditional compilation
- `src/libipc/sync/semaphore.cpp` - Updated conditional compilation
- `src/libipc/sync/waiter.cpp` - Updated conditional compilation

## References

- Issue #156: Support for FreeBSD
- FreeBSD pthread documentation: https://www.freebsd.org/cgi/man.cgi?query=pthread

## Related

Closes #156