### PR TITLE
mingw: lower case more Windows.h includes when using ming

### DIFF
--- a/src/libipc/platform/win/codecvt.h
+++ b/src/libipc/platform/win/codecvt.h
@@ -4,7 +4,11 @@
  */
 #pragma once
 
+#if defined(__MINGW32__)
+#include <windows.h>
+#else
 #include <Windows.h>
+#endif
 
 #include "libipc/imp/codecvt.h"
 #include "libipc/imp/detect_plat.h"

--- a/src/libipc/platform/win/system.h
+++ b/src/libipc/platform/win/system.h
@@ -7,7 +7,11 @@
 #include <exception>
 #include <type_traits>
 
+#if defined(__MINGW32__)
+#include <windows.h>
+#else
 #include <Windows.h>
+#endif
 #include <tchar.h>
 
 #include "libipc/imp/system.h"

--- a/test/archive/test_sync.cpp
+++ b/test/archive/test_sync.cpp
@@ -37,8 +37,11 @@ TEST(PThread, Robust) {
     pthread_mutex_destroy(&mutex);
 }
 #elif defined(LIBIPC_OS_WIN)
+#if defined(__MINGW32__)
+#include <windows.h>
+#else
 #include <Windows.h>
-#include <Windows.h>
+#endif
 #endif
 #include <tchar.h>
 


### PR DESCRIPTION
Some new Windows.h includes will fail under linux as they need to be lower case to cross compile to Windows.