### PR TITLE
msvc: avoid use of std::aligned_alloc as not available

### DIFF
--- a/src/libipc/mem/new_delete_resource.cpp
+++ b/src/libipc/mem/new_delete_resource.cpp
@@ -36,7 +36,7 @@ void *new_delete_resource::allocate(std::size_t bytes, std::size_t alignment) no
     log.error("invalid bytes = ", bytes, ", alignment = ", alignment);
     return nullptr;
   }
-#if defined(LIBIPC_CPP_17)
+#if defined(LIBIPC_CPP_17) && !defined(LIBIPC_CC_MSVC)
   /// \see https://en.cppreference.com/w/cpp/memory/c/aligned_alloc
   /// \remark The size parameter must be an integral multiple of alignment.
   return std::aligned_alloc(alignment, ipc::round_up(bytes, alignment));


### PR DESCRIPTION
MSVC does not have std::aligned_alloc and normally the checks here would be fine.

However if a project is detected as having 17/20 due it being compiled with /Zc:__cplusplus (as is the case here) it will fail to build as it picks std::aligned_alloc which it does not have.

This allows it to build.