### PR TITLE
webOS: fix std::aligned_alloc build error and extra param to sys:error

### DIFF
--- a/src/libipc/mem/new_delete_resource.cpp
+++ b/src/libipc/mem/new_delete_resource.cpp
@@ -36,7 +36,7 @@ void *new_delete_resource::allocate(std::size_t bytes, std::size_t alignment) no
     log.error("invalid bytes = ", bytes, ", alignment = ", alignment);
     return nullptr;
   }
-#if defined(LIBIPC_CPP_17) && !defined(LIBIPC_CC_MSVC) && !defined(__MINGW32__)
+#if defined(LIBIPC_CPP_17) && !defined(LIBIPC_CC_MSVC) && !defined(__MINGW32__) && !defined(__WEBOS__)
   /// \see https://en.cppreference.com/w/cpp/memory/c/aligned_alloc
   /// \remark The size parameter must be an integral multiple of alignment.
   return std::aligned_alloc(alignment, ipc::round_up(bytes, alignment));
@@ -55,7 +55,7 @@ void *new_delete_resource::allocate(std::size_t bytes, std::size_t alignment) no
   if (ret != 0) {
     log.error("failed: posix_memalign(alignment = ", alignment, 
                                        ", bytes = ", bytes, 
-                                      "). error = ", sys::error(ret));
+                                      "). error = ", sys::error());
     return nullptr;
   }
   return p;


### PR DESCRIPTION
I found another platform that doesn't have std::aligned_alloc!

Another issue:
sys:error does not take a param?


```
[ 50%] Linking CXX static library libinputcommon.a
/home/cscd98/Developer/dolphin-fml/Externals/cpp-ipc/cpp-ipc/src/libipc/mem/new_delete_resource.cpp: In member function ‘void* ipc::mem::new_delete_resource::allocate(std::size_t, std::size_t)’:
/home/cscd98/Developer/dolphin-fml/Externals/cpp-ipc/cpp-ipc/src/libipc/mem/new_delete_resource.cpp:58:64: error: too many arguments to function ‘std::error_code ipc::sys::error()’
   58 |                                       "). error = ", sys::error(ret));
```
